### PR TITLE
Fixed tests, better UTF-8 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 [0-9].out
 *.[0-9]
 *.cgo?.*
+*.swp
 _cgo_*
 _obj
 _test

--- a/pcre.go
+++ b/pcre.go
@@ -96,6 +96,7 @@ const (
 	NO_AUTO_CAPTURE   = C.PCRE_NO_AUTO_CAPTURE
 	UNGREEDY          = C.PCRE_UNGREEDY
 	UTF8              = C.PCRE_UTF8
+	UCP               = C.PCRE_UCP
 )
 
 // Flags for Match functions

--- a/pcre.go
+++ b/pcre.go
@@ -235,7 +235,7 @@ func pcregroups(ptr *C.pcre) (count C.int) {
 // Returns string with regex pattern and int with fpcre flags.
 // Flags are specified before the regex in form like this "(?flags)regex"
 // Supported symbols i=CASELESS; m=MULTILINE; s=DOTALL; U=UNGREEDY; J=DUPNAMES;
-// x=EXTENDED; X=EXTRA; D=DOLLAR_ENDONLY; u=UTF8;
+// x=EXTENDED; X=EXTRA; D=DOLLAR_ENDONLY; u=UTF8|UCP;
 func ParseFlags(ptr string) (string, int) {
 	fReg := MustCompile("^\\(\\?[a-zA-Z]+?\\)", 0)
 	flags := 0
@@ -266,7 +266,7 @@ func ParseFlags(ptr string) (string, int) {
 			flags = flags | UNGREEDY
 		}
 		if strings.Contains(fStr, "u") {
-			flags = flags | UTF8
+			flags = flags | UTF8 | UCP
 		}
 	}
 	return ptr, flags


### PR DESCRIPTION
Hi, I fixed the tests which did not compile.
And also I added a UCP = C.PCRE_UCP constant (stands for Unicode Character Properties) and modified the ParseFlags() function to treat "(?u)" as UTF8 | UCP. This is needed to make \b \w \s \B \W \S to work properly in Unicode patterns.

Just one example:
TEXT: "мощность 25 Вт"
REG: `(?ux) \b \d+ \s* Вт \b`
Without UCP in flags the pattern won't match "25 Вт" which is counterintuitive.