### PR TITLE
Study buffer size fixed

### DIFF
--- a/pcre_test.go
+++ b/pcre_test.go
@@ -129,6 +129,18 @@ func TestMatcher(t *testing.T) {
 	check(`^(.*)$`, "a\000c", "a\000c", "a\000c")
 }
 
+func TestNewMatcherJIT(t *testing.T) {
+	re := MustCompileJIT(`\dG|internet|gprs|[Kk]b|[Mm]b|Gb|lte`, 0, STUDY_JIT_COMPILE)
+	m := re.NewMatcherString(`4GKb`, 0)
+	if !m.Matches {
+		t.Error("The match should be matched")
+	}
+	m = re.NewMatcherString(`Some value`, 0)
+	if m.Matches {
+		t.Error("The match should not be matched")
+	}
+}
+
 func TestPartial(t *testing.T) {
 	re := MustCompile(`^abc`, 0)
 


### PR DESCRIPTION
I changed size for study data (it have fixed size and is not a not equal `pcreJITSize`). 
Before it worked because  `pcreJITSize` is bigger than size of pcre_extra structore (64 bytes on x86_x64 processor).

Also I replace `C.memcpy` on `C.GoBytes` utility. 