### PR TITLE
Allow Study regexp without JIT mode (it also speed up executing).

### DIFF
--- a/pcre.go
+++ b/pcre.go
@@ -311,7 +311,11 @@ func CompileJIT(pattern string, flagsC, flagsS int) (Regexp, error) {
 		extra: nil,
 	}
 
-	if errS := re.study(flagsS); errS != nil {
+	if (flagsS & STUDY_JIT_COMPILE) == 0 {
+		return re, errors.New("flagsS must contains pcre.STUDY_JIT_COMPILE flag")
+	}
+
+	if errS := re.Study(flagsS); errS != nil {
 		return re, fmt.Errorf("study error: %w", errS)
 	}
 
@@ -486,16 +490,11 @@ func (re Regexp) ReplaceAllString(subj, repl string, flags int) string {
 }
 
 // Study regexp and add pcre_extra information to it, which gives huge
-// speed boost when matching. If an error occurs, return value is
-// non-nil. If flags = 0, don't study at all and return error.
+// speed boost when matching. If an error occurs, return value is non-nil.
 // Studying can be quite a heavy optimization, but it's worth it.
-func (re *Regexp) study(flags int) error {
+func (re *Regexp) Study(flags int) error {
 	if re.extra != nil {
 		return errors.New("regexp already optimized")
-	}
-
-	if flags <= 0 {
-		return errors.New("flag must be > 0")
 	}
 
 	var err *C.char

--- a/pcre_test.go
+++ b/pcre_test.go
@@ -177,6 +177,53 @@ func TestCompileAndStudy(t *testing.T) {
 	}
 }
 
+func BenchmarkStudyAndExec(b *testing.B) {
+	// Date check regexp
+	re := MustCompile(`/^(?:(?:31(\/|-|\.)(?:0?[13578]|1[02]))\1|(?:(?:29|30)(\/|-|\.)(?:0?[1,3-9]|1[0-2])\2))(?:(?:1[6-9]|[2-9]\d)?\d{2})$|^(?:29(\/|-|\.)0?2\3(?:(?:(?:1[6-9]|[2-9]\d)?(?:0[48]|[2468][048]|[13579][26])|(?:(?:16|[2468][048]|[3579][26])00))))$|^(?:0?[1-9]|1\d|2[0-8])(\/|-|\.)(?:(?:0?[1-9])|(?:1[0-2]))\4(?:(?:1[6-9]|[2-9]\d)?\d{2})$/`, 0)
+	err := re.Study(0)
+	if err != nil {
+		b.Error("Study error", err)
+	}
+	subj := []byte(`20-10-2023`)
+	m := re.NewMatcher(subj, 0)
+	for i := 0; i < b.N; i++ {
+		m.MatchWFlags(subj, 0)
+		if m == nil {
+			b.Error("The match should be matched")
+		}
+	}
+}
+
+func BenchmarkExecJIT(b *testing.B) {
+	// Date check regexp
+	re := MustCompile(`/^(?:(?:31(\/|-|\.)(?:0?[13578]|1[02]))\1|(?:(?:29|30)(\/|-|\.)(?:0?[1,3-9]|1[0-2])\2))(?:(?:1[6-9]|[2-9]\d)?\d{2})$|^(?:29(\/|-|\.)0?2\3(?:(?:(?:1[6-9]|[2-9]\d)?(?:0[48]|[2468][048]|[13579][26])|(?:(?:16|[2468][048]|[3579][26])00))))$|^(?:0?[1-9]|1\d|2[0-8])(\/|-|\.)(?:(?:0?[1-9])|(?:1[0-2]))\4(?:(?:1[6-9]|[2-9]\d)?\d{2})$/`, 0)
+	err := re.Study(STUDY_JIT_COMPILE)
+	if err != nil {
+		b.Error("Study error", err)
+	}
+	subj := []byte(`20-10-2023`)
+	m := re.NewMatcher(subj, 0)
+	for i := 0; i < b.N; i++ {
+		m.MatchWFlags(subj, 0)
+		if m == nil {
+			b.Error("The match should be matched")
+		}
+	}
+}
+
+func BenchmarkExecWithoutStudy(b *testing.B) {
+	// Date check regexp
+	re := MustCompile(`/^(?:(?:31(\/|-|\.)(?:0?[13578]|1[02]))\1|(?:(?:29|30)(\/|-|\.)(?:0?[1,3-9]|1[0-2])\2))(?:(?:1[6-9]|[2-9]\d)?\d{2})$|^(?:29(\/|-|\.)0?2\3(?:(?:(?:1[6-9]|[2-9]\d)?(?:0[48]|[2468][048]|[13579][26])|(?:(?:16|[2468][048]|[3579][26])00))))$|^(?:0?[1-9]|1\d|2[0-8])(\/|-|\.)(?:(?:0?[1-9])|(?:1[0-2]))\4(?:(?:1[6-9]|[2-9]\d)?\d{2})$/`, 0)
+	subj := []byte(`20-10-2023`)
+	m := re.NewMatcher(subj, 0)
+	for i := 0; i < b.N; i++ {
+		m.MatchWFlags(subj, 0)
+		if m == nil {
+			b.Error("The match should be matched")
+		}
+	}
+}
+
 func TestPartial(t *testing.T) {
 	re := MustCompile(`^abc`, 0)
 

--- a/pcre_test.go
+++ b/pcre_test.go
@@ -141,6 +141,42 @@ func TestNewMatcherJIT(t *testing.T) {
 	}
 }
 
+func TestCompileAndStudy(t *testing.T) {
+	re, err := Compile(`(Bel[ao]rus)|(Бел[ао]рус)|(БЕЛ[АО]РУС)|Білорусь`, UTF8|CASELESS)
+	if err != nil {
+		t.Error("Compile error", err)
+	}
+	if len(re.extra) != 0 {
+		t.Error("re.extra should be empty")
+	}
+
+	m := re.NewMatcherString("Беларусь: MTS", 0)
+	if !m.Matches {
+		t.Error("The match should be matched")
+	}
+	m = re.NewMatcherString("Other value", 0)
+	if m.Matches {
+		t.Error("The match should not be matched")
+	}
+
+	err = re.Study(0)
+	if err != nil {
+		t.Error("Study error", err)
+	}
+	if len(re.extra) == 0 {
+		t.Error("re.extra should not be empty")
+	}
+
+	m = re.NewMatcherString("Беларусь: MTS", 0)
+	if !m.Matches {
+		t.Error("The match should be matched")
+	}
+	m = re.NewMatcherString("Other value", 0)
+	if m.Matches {
+		t.Error("The match should not be matched")
+	}
+}
+
 func TestPartial(t *testing.T) {
 	re := MustCompile(`^abc`, 0)
 


### PR DESCRIPTION
PCRE allow to study REGEX without JIT.
Now it can be done because `extra` size now calculating correctly (not as JIT size).